### PR TITLE
feat: refresh site layout and colors

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,47 @@
+:root {
+  --bs-primary: #1e40af;
+  --bs-primary-50: #eff6ff;
+  --bs-primary-100: #dbeafe;
+  --bs-primary-200: #bfdbfe;
+  --bs-primary-300: #93c5fd;
+  --bs-primary-400: #60a5fa;
+  --bs-primary-500: #3b82f6;
+  --bs-primary-600: #2563eb;
+  --bs-primary-700: #1d4ed8;
+  --bs-primary-800: #1e40af;
+  --bs-primary-900: #1e3a8a;
+  --bs-primary-rgb: 30, 64, 175;
+  --bs-secondary: #f1f5f9;
+  --bs-secondary-100: #e2e8f0;
+  --bs-secondary-200: #cbd5e1;
+  --bs-secondary-300: #94a3b8;
+  --bs-secondary-400: #64748b;
+  --bs-secondary-500: #475569;
+  --bs-secondary-600: #334155;
+  --bs-secondary-700: #1e293b;
+  --bs-secondary-800: #0f172a;
+  --bs-secondary-rgb: 241, 245, 249;
+}
+
+body {
+  background-color: var(--bs-secondary);
+  color: #1f2937;
+  line-height: 1.6;
+}
+
+header,
+footer {
+  background-color: var(--bs-primary);
+  color: #ffffff;
+}
+
+header a,
+footer a {
+  color: #ffffff;
+}
+
+.main-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}

--- a/index.html
+++ b/index.html
@@ -153,6 +153,7 @@
 
         <!-- include main style -->
         <link rel="stylesheet" href="./assets/css/theme/main.min.purge.css" />
+        <link rel="stylesheet" href="./assets/css/custom.css" />
 
         <!-- include scripts -->
         <script src="./assets/js/uni-core/js/uni-core-bundle.min.js"></script>
@@ -1366,7 +1367,7 @@
         <!-- Header end -->
 
         <!-- Wrapper start -->
-        <div id="wrapper" class="wrap">
+        <div id="wrapper" class="wrap main-container">
             <!-- Section start -->
             <div
                 id="hero_header"


### PR DESCRIPTION
## Summary
- introduce custom stylesheet with modern color variables
- apply centered layout and link new styles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx prettier --write assets/css/custom.css`

------
https://chatgpt.com/codex/tasks/task_e_6897a44008748333a265dbca45542e93